### PR TITLE
STAutoField#blurred selects a result when selectedResult == 0.  Previously returned false

### DIFF
--- a/lib/ST/STAutoField.js
+++ b/lib/ST/STAutoField.js
@@ -281,7 +281,7 @@ STView.subClass('STAutoField', {
     
     blurred: function()
     {
-        if (this.mouseOverResults && this.selectedResult) {
+        if (this.mouseOverResults && this.selectedResult!=null) {
             this.selectResult(this.results[this.selectedResult]);
         } else {
             if (this.inputElement.val() == '') {


### PR DESCRIPTION
[9719673]  Fixed issue where first result wasn't selectable onclick in STAutoField#blurred
- selectedResult gave a false negative on the if statement.
